### PR TITLE
fix datatype for boolean values

### DIFF
--- a/twitcher/datatype.py
+++ b/twitcher/datatype.py
@@ -50,7 +50,10 @@ class Service(dict):
     def public(self):
         """Flag if service has public access."""
         # TODO: public access can be set via auth parameter.
-        return self.get('public') or False
+        value = self.get('public', False)
+        if value is True or value == 1 or value == 'true':
+            return True
+        return False
 
     @property
     def auth(self):
@@ -60,7 +63,10 @@ class Service(dict):
     @property
     def verify(self):
         """Verify ssl service certificate."""
-        return self.get('verify') or True
+        value = self.get('verify', True)
+        if value is False or value == 0 or value == 'false':
+            return False
+        return True
 
     @property
     def params(self):

--- a/twitcher/store.py
+++ b/twitcher/store.py
@@ -148,8 +148,8 @@ class ServiceStore(ServiceStoreInterface):
                 url=baseurl(service.url),
                 type=service.type,
                 purl=service.purl,
-                public=service.public,
-                verify=service.verify,
+                public=int(service.public),
+                verify=int(service.verify),
                 auth=service.auth))
         except DBAPIError:
             raise DatabaseError


### PR DESCRIPTION
sqlite does not handle boolean values and we use integer. This PR tries to handle the boolean parameter handling (public, verify) for both sqlite and postgres.