### PR TITLE
Fix service store insert or update

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -54,3 +54,29 @@ class ServiceStoreTestCase(BaseTest):
         assert len(services) == 1
         self.service_store.delete_service(name='flamingo')
         self.service_store.clear_services()
+
+    def test_service_store_insert_or_update(self):
+        self.service_store.save_service(
+            Service(
+                name="albatross",
+                url="http://somewhere.over.the/ocean",
+                type="wps",
+                public=False,
+                auth='token',
+                verify=True,
+                purl="http://purl/wps")
+        )
+        # update
+        self.service_store.save_service(
+            Service(
+                name="albatross",
+                url="http://somewhere.over.the/ocean",
+                type="wps",
+                public=True,
+                auth='token',
+                verify=True,
+                purl="http://purl/wps")
+        )
+        services = self.service_store.list_services()
+        assert len(services) == 1
+        self.service_store.clear_services()

--- a/twitcher/store.py
+++ b/twitcher/store.py
@@ -138,19 +138,32 @@ class ServiceStore(ServiceStoreInterface):
 
     def save_service(self, service):
         """
-        Stores an OWS service in database.
+        Stores an OWS service in database (insert or update).
 
         :param service: An instance of :class:`twitcher.datatype.Service`.
         """
         try:
-            self.request.dbsession.merge(models.Service(
-                name=service.name,
-                url=baseurl(service.url),
-                type=service.type,
-                purl=service.purl,
-                public=int(service.public),
-                verify=int(service.verify),
-                auth=service.auth))
+            query = self.request.dbsession.query(models.Service)
+            one = query.filter(models.Service.name == service.name).first()
+            if one:
+                # update
+                one.url = baseurl(service.url)
+                one.type = service.type
+                one.purl = service.purl
+                one.public = int(service.public)
+                one.verify = int(service.verify)
+                one.auth = service.auth
+                self.request.dbsession.merge(one)
+            else:
+                # insert
+                self.request.dbsession.add(models.Service(
+                    name=service.name,
+                    url=baseurl(service.url),
+                    type=service.type,
+                    purl=service.purl,
+                    public=int(service.public),
+                    verify=int(service.verify),
+                    auth=service.auth))
         except DBAPIError:
             raise DatabaseError
 


### PR DESCRIPTION
This PR fixes the service store `save` method. It inserts a new service or updates an existing one (identified by service name).