### PR TITLE
don't lose config if provided directly (#69)

### DIFF
--- a/twitcher/adapter/base.py
+++ b/twitcher/adapter/base.py
@@ -24,8 +24,8 @@ class AdapterInterface(object):
         """
         raise NotImplementedError
 
-    def configurator_factory(self, request):
-        # type: (Request) -> Configurator
+    def configurator_factory(self, container):
+        # type: (AnySettingsContainer) -> Configurator
         """
         Returns the 'configurator' implementation of the adapter.
         """
@@ -52,8 +52,8 @@ class AdapterInterface(object):
         """
         raise NotImplementedError
 
-    def owsproxy_config(self, request):
-        # type: (Request) -> None
+    def owsproxy_config(self, config):
+        # type: (AnySettingsContainer) -> None
         """
         Returns the 'owsproxy' implementation of the adapter.
         """

--- a/twitcher/adapter/default.py
+++ b/twitcher/adapter/default.py
@@ -15,8 +15,8 @@ class DefaultAdapter(AdapterInterface):
         from twitcher.__version__ import __version__
         return {"name": "default", "version": str(__version__)}
 
-    def configurator_factory(self, request):
-        settings = get_settings(request)
+    def configurator_factory(self, container):
+        settings = get_settings(container)
         return Configurator(settings=settings)
 
     def tokenstore_factory(self, request):
@@ -30,7 +30,9 @@ class DefaultAdapter(AdapterInterface):
         service_store = self.servicestore_factory(request)
         return OWSSecurity(token_store, service_store)
 
-    def owsproxy_config(self, request):
+    def owsproxy_config(self, container):
         from twitcher.owsproxy import owsproxy_defaultconfig
-        config = self.configurator_factory(request)
-        owsproxy_defaultconfig(config)
+        # update provided config or generate it otherwise
+        if not isinstance(container, Configurator):
+            container = self.configurator_factory(container)
+        owsproxy_defaultconfig(container)


### PR DESCRIPTION
- modify inputs to use allowed types
- preserve configurator that could already contain some included config from previous calls (#69)