### PR TITLE
Import adapter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,20 @@ Changes
 Unreleased
 ==========
 
+New Features:
+
+* Add `postgres` extra requirements for when it is used as database driver with `sqlalchemy`.
+
+Changes:
+
+* Use ``container`` instead of ``config`` for ``AdapterInterface.owsproxy_config`` to match real use cases.
+
+Fixes:
+
+* Improve the adapter import methodology to work with more use cases (https://github.com/Ouranosinc/Magpie/issues/182).
+* Fix incorrect setup for bump version within `Makefile`.
+* Fix Twitcher `main` including ``twitcher.<module>`` instead of ``.<module>``.
+
 0.5.0 (2019-05-22)
 ==================
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Configuration
-VERSION := VERSION := birdhouse/twitcher:0.5.0
+VERSION := 0.5.0
 APP_ROOT := $(abspath $(lastword $(MAKEFILE_LIST))/..)
 INI_FILE ?= development.ini
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ argcomplete
 pytz
 lxml
 pyopenssl
+six
 # debug
 pyramid_debugtoolbar
 # deploy

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,19 +4,19 @@ commit = True
 tag = True
 
 [bumpversion:file:CHANGES.rst]
-search = 
+search =
 	Unreleased
 	==========
-replace = 
+replace =
 	Unreleased
 	==========
-	
+
 	{new_version} ({now:%%Y-%%m-%%d})
 	==================
 
 [bumpversion:file:Makefile]
 search = VERSION := birdhouse/twitcher:{current_version}
-replace = VERSION := birdhouse/twitcher:{new_version}
+replace = {new_version}
 
 [bumpversion:file:twitcher/__version__.py]
 search = __version__ = '{current_version}'
@@ -30,18 +30,18 @@ replace = release = '{new_version}'
 description-file = README.rst
 
 [tool:pytest]
-addopts = 
+addopts =
 	--strict
 	--tb=native
 python_files = test_*.py
-markers = 
+markers =
 	online: mark test to need internet connection
 	slow: mark test to be slow
 
 [flake8]
 ignore = F401,E402
 max-line-length = 120
-exclude = 
+exclude =
 	.git,
 	__pycache__,
 	twitcher/alembic/versions,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,10 @@ setup(name='pyramid_twitcher',
       zip_safe=False,
       test_suite='twitcher',
       install_requires=reqs,
-      extras_require={"dev": dev_reqs},  # pip install ".[dev]"
+      extras_require={
+          "dev": dev_reqs,              # pip install ".[dev]"
+          "postgres": ["psycopg2"],     # when using postgres database driver with sqlalchemy
+      },
       entry_points="""\
       [paste.app_factory]
       main = twitcher:main

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -42,17 +42,17 @@ class DummyAdapter(AdapterInterface):
 
 
 # noinspection PyPep8Naming
-def test_adapter_factory_DummyAdapter_valid_import_with_inits():
+def test_adapter_factory_DummyAdapter_valid_import_with_init():
     settings = {'twitcher.adapter': DummyAdapter.name}
     adapter = get_adapter_factory(settings)
-    assert isinstance(adapter, DummyAdapter), "Expect {!s}, but got {!s}".format(TestAdapter, type(adapter))
+    assert isinstance(adapter, DummyAdapter), "Expect {!s}, but got {!s}".format(DummyAdapter, type(adapter))
 
 
 def make_path(base, other='__init__.py'):
     return str(Path(base) / Path(other))
 
 
-def test_adapter_factory_TmpAdapter_valid_import_installed_without_inits():
+def test_adapter_factory_TmpAdapter_valid_import_installed_without_init():
     """
     Test a valid installed adapter import by setting although not located under same directory,
     with much deeper structure, and without any '__init__.py' defining a python 'package'.

--- a/twitcher/__init__.py
+++ b/twitcher/__init__.py
@@ -8,10 +8,10 @@ def main(global_config, **settings):
     """
     with Configurator(settings=settings) as config:
         # include twitcher components
-        config.include('.models')
-        config.include('.frontpage')
-        config.include('.rpcinterface')
-        config.include('.owsproxy')
+        config.include('twitcher.models')
+        config.include('twitcher.frontpage')
+        config.include('twitcher.rpcinterface')
+        config.include('twitcher.owsproxy')
         # tweens/middleware
         # TODO: maybe add tween for exception handling or use unknown_failure view
         config.include('twitcher.tweens')

--- a/twitcher/adapter/__init__.py
+++ b/twitcher/adapter/__init__.py
@@ -1,6 +1,7 @@
-from twitcher.adapter.default import DefaultAdapter, AdapterInterface
+from twitcher.adapter.default import DefaultAdapter, TWITCHER_ADAPTER_DEFAULT
+from twitcher.adapter.base import AdapterInterface
 from twitcher.utils import get_settings
-
+from importlib import import_module
 from inspect import isclass
 from typing import TYPE_CHECKING
 
@@ -15,21 +16,20 @@ if TYPE_CHECKING:
     from typing import AnyStr, Type, Union
 
 
-TWITCHER_ADAPTER_DEFAULT = 'default'
-
-
 def import_adapter(name):
     # type: (AnyStr) -> Type[AdapterInterface]
     """Attempts import of the class specified by python string ``package.module.class``."""
     components = name.split('.')
     mod_name = components[0]
-    mod = __import__(mod_name)
+    mod = import_module(mod_name)
     for comp in components[1:]:
         if not hasattr(mod, comp):
+            mod_from = mod_name
             mod_name = '{mod}.{sub}'.format(mod=mod_name, sub=comp)
-            mod = __import__(mod_name, fromlist=[mod_name])
+            mod = import_module(mod_name, package=mod_from)
             continue
         mod = getattr(mod, comp)
+        mod_name = mod.__name__
     if not isclass(mod) or not issubclass(mod, AdapterInterface):
         raise TypeError("Invalid reference is not of type '{}.{}'."
                         .format(AdapterInterface.__module__, AdapterInterface.__name__))

--- a/twitcher/adapter/base.py
+++ b/twitcher/adapter/base.py
@@ -63,7 +63,7 @@ class AdapterInterface(six.with_metaclass(AdapterBase)):
         """
         raise NotImplementedError
 
-    def owsproxy_config(self, config):
+    def owsproxy_config(self, container):
         # type: (AnySettingsContainer) -> None
         """
         Returns the 'owsproxy' implementation of the adapter.

--- a/twitcher/adapter/base.py
+++ b/twitcher/adapter/base.py
@@ -1,6 +1,7 @@
 from twitcher.utils import get_settings
 
 from typing import TYPE_CHECKING
+import six
 if TYPE_CHECKING:
     from twitcher.typedefs import AnySettingsContainer, JSON
     from twitcher.store import AccessTokenStoreInterface, ServiceStoreInterface
@@ -9,13 +10,23 @@ if TYPE_CHECKING:
     from pyramid.request import Request
 
 
-class AdapterInterface(object):
+class AdapterBase(type):
+    @property
+    def name(cls):
+        return '{}.{}'.format(cls.__module__, cls.__name__)
+
+
+class AdapterInterface(six.with_metaclass(AdapterBase)):
     """
     Common interface allowing functionality overriding using an adapter implementation.
     """
     def __init__(self, container):
         # type: (AnySettingsContainer) -> None
         self.settings = get_settings(container)
+
+    @classmethod
+    def name(cls):
+        return '{}.{}'.format(cls.__module__, cls.__name__)
 
     def describe_adapter(self):
         # type: () -> JSON

--- a/twitcher/adapter/default.py
+++ b/twitcher/adapter/default.py
@@ -2,18 +2,27 @@
 Factories to create storage backends.
 """
 
-from twitcher.adapter.base import AdapterInterface
+from twitcher.adapter.base import AdapterInterface, AdapterBase
 from twitcher.store import AccessTokenStore, ServiceStore
 from twitcher.owssecurity import OWSSecurity
 from twitcher.utils import get_settings
 
 from pyramid.config import Configurator
+import six
+
+TWITCHER_ADAPTER_DEFAULT = 'default'
 
 
-class DefaultAdapter(AdapterInterface):
+class DefaultBase(AdapterBase):
+    @property
+    def name(cls):
+        return TWITCHER_ADAPTER_DEFAULT
+
+
+class DefaultAdapter(six.with_metaclass(DefaultBase, AdapterInterface)):
     def describe_adapter(self):
         from twitcher.__version__ import __version__
-        return {"name": "default", "version": str(__version__)}
+        return {"name": self.name, "version": str(__version__)}
 
     def configurator_factory(self, container):
         settings = get_settings(container)


### PR DESCRIPTION
This PR improves the `import_adapter` function to allow import of `magpie.adapter.MagpieAdapter` as described in https://github.com/Ouranosinc/Magpie/issues/182 while preserving current & previous import methods.

Adds test for new import method.

Also adds other changes as described in `CHANGES.rst`.