### PR TITLE
update readme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changes
 Unreleased
 ==========
 
+New Features:
+
+Changes:
+* Updated `README.rst` to match recent development, reference and docker image link.
+
+Fixes:
+
 0.5.1 (2019-05-24)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,8 @@ Twitcher is implemented with the Python `Pyramid`_ web framework.
 
 Twitcher is part of the `Birdhouse`_ project. The documentation is on `ReadTheDocs`_.
 
+Twitcher `Docker`_ images are also available for most recent tagged versions.
+
 .. _Birdhouse: http://birdhouse.readthedocs.io/en/latest/
 .. _Pyramid: http://www.pylonsproject.org
 .. _ReadTheDocs: http://twitcher.readthedocs.io/en/latest/
@@ -49,3 +51,4 @@ Twitcher is part of the `Birdhouse`_ project. The documentation is on `ReadTheDo
 .. _Weaver: https://github.com/crim-ca/weaver
 .. _CRIM: https://www.crim.ca/en
 .. _Swagger: https://swagger.io/
+.. _Docker: https://cloud.docker.com/u/birdhouse/repository/docker/birdhouse/twitcher/general

--- a/README.rst
+++ b/README.rst
@@ -34,9 +34,8 @@ and might also be used for Thredds catalog services.
 Twitcher extensions:
 
 * `Magpie`_ is an AuthN/AuthZ service provided by the `PAVICS`_ project.
-
-There is also the Weaver_ middleware by CRIM_.
-A fork of Twitcher for workflow execution and a Swagger_ RESTful interface for Web Processing Services.
+* `Weaver`_  middleware by CRIM_. A reimplementation of an old `Twitcher fork <https://github.com/ouranosinc/twitcher/>`_
+  for workflow execution and a Swagger RESTful interface for Web Processing Services.
 
 Twitcher is implemented with the Python `Pyramid`_ web framework.
 


### PR DESCRIPTION
Note: 
I have also updated the doc similarly on dockerhub
https://cloud.docker.com/u/birdhouse/repository/docker/birdhouse/twitcher/general

The `latest` is auto-built on new merges as well as for new version tags.
Tagged images are created with same value as specified according to #76.