### PR TITLE
Information API routes 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,12 @@ Unreleased
 ==========
 
 New Features:
+* Adds route `/info` which returns contents of `twitcher.__version__`.
+* Adds route `/versions` which returns version details such as `Twitcher` app version and employed adapter version.
 
 Changes:
 * Updated `README.rst` to match recent development, reference and docker image link.
+* Adds URI of `/info` and `/versions` routes in the frontpage response.
 
 Fixes:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ argcomplete
 pytz
 lxml
 pyopenssl
-six
 # debug
 pyramid_debugtoolbar
 # deploy

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dev_reqs = [line.strip() for line in open('requirements_dev.txt')]
 
 setup(name='pyramid_twitcher',
       version=about['__version__'],
-      description='Security Proxy for OGC Services like WPS.',
+      description=about['__doc__'],
       long_description=README + '\n\n' + CHANGES,
       classifiers=[
           "Programming Language :: Python",

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -28,7 +28,7 @@ def test_adapter_factory_none_specified():
     assert isinstance(adapter, DefaultAdapter), "Expect {!s}, but got {!s}".format(DefaultAdapter, type(adapter))
 
 
-# noinspection PyAbstractClass
+# noinspection PyAbstractClass,PyMethodMayBeStatic
 class DummyAdapter(AdapterInterface):
     def servicestore_factory(self, request):
         class DummyServiceStore(ServiceStoreInterface):
@@ -43,7 +43,7 @@ class DummyAdapter(AdapterInterface):
 
 # noinspection PyPep8Naming
 def test_adapter_factory_DummyAdapter_valid_import_with_init():
-    settings = {'twitcher.adapter': DummyAdapter.name}
+    settings = {'twitcher.adapter': DummyAdapter({}).name}
     adapter = get_adapter_factory(settings)
     assert isinstance(adapter, DummyAdapter), "Expect {!s}, but got {!s}".format(DummyAdapter, type(adapter))
 
@@ -104,7 +104,7 @@ def test_adapter_factory_TestAdapter_invalid_raised():
 
 # noinspection PyTypeChecker
 def test_adapter_factory_call_servicestore_factory():
-    settings = {'twitcher.adapter': DummyAdapter.name}
+    settings = {'twitcher.adapter': DummyAdapter({}).name}
     adapter = get_adapter_factory(settings)
     store = adapter.servicestore_factory(DummyRequest())
     assert isinstance(store, ServiceStoreInterface)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,6 @@
 """
 Testing the Twitcher API.
 """
-import pytest
 
 from .common import BaseTest, dummy_request
 

--- a/tests/test_frontpage.py
+++ b/tests/test_frontpage.py
@@ -1,0 +1,47 @@
+from .common import BaseTest
+
+from twitcher import main, __version__
+from twitcher.adapter.default import TWITCHER_ADAPTER_DEFAULT
+from twitcher.frontpage import INFORMATION_PATH, VERSIONS_PATH
+
+from pyramid import testing
+from webtest import TestApp
+import unittest
+
+
+class TestFrontpageAPI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.settings = {
+            'twitcher.url': 'localhost',
+            'sqlalchemy.url': 'sqlite:///:memory:'
+        }
+        cls.config = testing.setUp(settings=cls.settings)
+        cls.app = TestApp(main({}, **cls.config.registry.settings))
+
+    def test_get_frontpage(self):
+        resp = self.app.get('/')
+        assert resp.status_code == 200
+        assert resp.json['message'] == 'Twitcher Frontpage'
+        assert resp.json['information_uri'] == self.settings['twitcher.url'] + INFORMATION_PATH
+        assert resp.json['versions_uri'] == self.settings['twitcher.url'] + VERSIONS_PATH
+
+    def test_get_info(self):
+        resp = self.app.get(INFORMATION_PATH)
+        assert resp.status_code == 200
+        assert resp.json['author'] == __version__.__author__
+        assert resp.json['doc'] == __version__.__doc__
+        assert resp.json['email'] == __version__.__email__
+        assert resp.json['package'] == 'twitcher'
+        assert resp.json['version'] == __version__.__version__
+
+    def test_get_versions(self):
+        resp = self.app.get(VERSIONS_PATH)
+        assert resp.status_code == 200
+        assert isinstance(resp.json, list)
+        assert resp.json[0]['name'] == 'Twitcher'
+        assert resp.json[0]['type'] == 'application'
+        assert resp.json[0]['version'] == __version__.__version__
+        assert resp.json[1]['name'] == TWITCHER_ADAPTER_DEFAULT
+        assert resp.json[1]['type'] == 'adapter'
+        assert resp.json[1]['version'] == __version__.__version__

--- a/twitcher/__init__.py
+++ b/twitcher/__init__.py
@@ -1,7 +1,5 @@
 from pyramid.config import Configurator
 
-from .__version__ import __author__, __email__, __version__
-
 
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.

--- a/twitcher/__version__.py
+++ b/twitcher/__version__.py
@@ -3,7 +3,7 @@
 # This information is located in its own file so that it can be loaded
 # without importing the main package when its dependencies are not installed.
 # See: https://packaging.python.org/guides/single-sourcing-package-version
-
+__doc__ = """Security Proxy for OGC Services like WPS."""
 __author__ = """Carsten Ehbrecht"""
 __email__ = 'ehbrecht@dkrz.de'
 __version__ = '0.5.1'

--- a/twitcher/adapter/base.py
+++ b/twitcher/adapter/base.py
@@ -1,7 +1,6 @@
 from twitcher.utils import get_settings
 
 from typing import TYPE_CHECKING
-import six
 if TYPE_CHECKING:
     from twitcher.typedefs import AnySettingsContainer, JSON
     from twitcher.store import AccessTokenStoreInterface, ServiceStoreInterface
@@ -10,13 +9,7 @@ if TYPE_CHECKING:
     from pyramid.request import Request
 
 
-class AdapterBase(type):
-    @property
-    def name(cls):
-        return '{}.{}'.format(cls.__module__, cls.__name__)
-
-
-class AdapterInterface(six.with_metaclass(AdapterBase)):
+class AdapterInterface(object):
     """
     Common interface allowing functionality overriding using an adapter implementation.
     """
@@ -24,9 +17,9 @@ class AdapterInterface(six.with_metaclass(AdapterBase)):
         # type: (AnySettingsContainer) -> None
         self.settings = get_settings(container)
 
-    @classmethod
-    def name(cls):
-        return '{}.{}'.format(cls.__module__, cls.__name__)
+    @property
+    def name(self):
+        return '{}.{}'.format(self.__module__, type(self).__name__)
 
     def describe_adapter(self):
         # type: () -> JSON

--- a/twitcher/adapter/default.py
+++ b/twitcher/adapter/default.py
@@ -2,24 +2,20 @@
 Factories to create storage backends.
 """
 
-from twitcher.adapter.base import AdapterInterface, AdapterBase
+from twitcher.adapter.base import AdapterInterface
 from twitcher.store import AccessTokenStore, ServiceStore
 from twitcher.owssecurity import OWSSecurity
 from twitcher.utils import get_settings
-
 from pyramid.config import Configurator
-import six
 
 TWITCHER_ADAPTER_DEFAULT = 'default'
 
 
-class DefaultBase(AdapterBase):
+class DefaultAdapter(AdapterInterface):
     @property
-    def name(cls):
+    def name(self):
         return TWITCHER_ADAPTER_DEFAULT
 
-
-class DefaultAdapter(six.with_metaclass(DefaultBase, AdapterInterface)):
     def describe_adapter(self):
         from twitcher.__version__ import __version__
         return {"name": self.name, "version": str(__version__)}

--- a/twitcher/frontpage.py
+++ b/twitcher/frontpage.py
@@ -29,7 +29,12 @@ def information(request):
 def versions(request):
     """List version details of components used by the API."""
     adapter_version = get_adapter_factory(request).describe_adapter()
-    twitcher_version = {'name': 'Twitcher', 'version': __version__.__version__}
+    adapter_version['type'] = 'adapter'
+    twitcher_version = {
+        'name': 'Twitcher',
+        'version': __version__.__version__,
+        'type': 'application',
+    }
     return [twitcher_version, adapter_version]
 
 

--- a/twitcher/frontpage.py
+++ b/twitcher/frontpage.py
@@ -1,10 +1,39 @@
+from twitcher.adapter import get_adapter_factory
+from twitcher.utils import get_twitcher_url, is_json_serializable
+from twitcher import __version__
 from pyramid.view import view_config
+
+VERSIONS_PATH = '/versions'
+INFORMATION_PATH = '/info'
 
 
 @view_config(route_name='frontpage', renderer='json')
 def frontpage(request):
-    return {'message': 'Twitcher Frontpage'}
+    return {
+        'message': 'Twitcher Frontpage',
+        'information_uri': get_twitcher_url(request) + INFORMATION_PATH,
+        'versions_uri': get_twitcher_url(request) + VERSIONS_PATH,
+    }
+
+
+@view_config(route_name='information', renderer='json')
+def information(request):
+    """List API information."""
+    return dict((i.replace('__', ''), getattr(__version__, i))
+                for i in dir(__version__)
+                if i not in ['__file__', '__name__', '__cached__']
+                and is_json_serializable(getattr(__version__, i)))
+
+
+@view_config(route_name='versions', renderer='json')
+def versions(request):
+    """List version details of components used by the API."""
+    adapter_version = get_adapter_factory(request).describe_adapter()
+    twitcher_version = {'name': 'Twitcher', 'version': __version__.__version__}
+    return [twitcher_version, adapter_version]
 
 
 def includeme(config):
     config.add_route('frontpage', '/')
+    config.add_route('information', INFORMATION_PATH)
+    config.add_route('versions', VERSIONS_PATH)

--- a/twitcher/frontpage.py
+++ b/twitcher/frontpage.py
@@ -19,10 +19,11 @@ def frontpage(request):
 @view_config(route_name='information', renderer='json')
 def information(request):
     """List API information."""
-    return dict((i.replace('__', ''), getattr(__version__, i))
-                for i in dir(__version__)
-                if i not in ['__file__', '__name__', '__cached__']
-                and is_json_serializable(getattr(__version__, i)))
+    return dict(
+        (i.replace('__', ''), getattr(__version__, i))
+        for i in dir(__version__)
+        if i not in ['__file__', '__name__', '__cached__'] and is_json_serializable(getattr(__version__, i))
+    )
 
 
 @view_config(route_name='versions', renderer='json')

--- a/twitcher/utils.py
+++ b/twitcher/utils.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from urllib import parse as urlparse
 from lxml import etree
 from typing import TYPE_CHECKING
+import json
 import time
 import pytz
 import re
@@ -56,6 +57,14 @@ def is_valid_url(url):
         return False
 
 
+def is_json_serializable(item):
+    try:
+        json.dumps(item)
+        return True
+    except (TypeError, OverflowError):
+        return False
+
+
 def parse_service_name(url, protected_path):
     parsed_url = urlparse.urlparse(url)
     service_name = None
@@ -95,7 +104,7 @@ def localize_datetime(dt, tz_name='UTC'):
         timezone = pytz.timezone(tz_name)
         tz_aware_dt = aware.astimezone(timezone)
     else:
-        LOGGER.warn('tzinfo already set')
+        LOGGER.warning('tzinfo already set')
     return tz_aware_dt
 
 


### PR DESCRIPTION
- Removes the need for `six` requirement by simplifying the base adapter interface.
- Adds routes that help us figure out what is the deployed Twitcher on a given server without actually having to ssh to the remove server.
- Adds unittests for corresponding routes.

`/` (frontpage): 
```
{
    "message": "Twitcher Frontpage",
    "information_uri": "http://localhost:8000/info",
    "versions_uri": "http://localhost:8000/versions"
}
```
note: hostname will match `twitcher.url` setting

`/info`: 
```
{
    "author": "Carsten Ehbrecht",
    "doc": "Security Proxy for OGC Services like WPS.",
    "email": "ehbrecht@dkrz.de",
    "package": "twitcher",
    "version": "0.5.1"
}
```
`/versions`: 
```
[
    {
        "name": "Twitcher",
        "version": "0.5.1",
        "type": "application"
    },
    {
        "name": "default",
        "version": "0.5.1",
        "type": "adapter"
    }
]
```



