### PR TITLE
Http status codes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,15 @@ Unreleased
 ==========
 
 New Features:
+
 * Adds route `/info` which returns contents of `twitcher.__version__`.
 * Adds route `/versions` which returns version details such as `Twitcher` app version and employed adapter version.
 
 Changes:
+
 * Updated `README.rst` to match recent development, reference and docker image link.
 * Adds URI of `/info` and `/versions` routes in the frontpage response.
+* Corresponding HTTP status codes are returned for raised ``OWSException``.
 
 Fixes:
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -11,7 +11,7 @@ WPS_CAPS_EMU_XML = os.path.join(RESOURCES_PATH, 'wps_caps_emu.xml')
 WMS_CAPS_NCWMS2_111_XML = os.path.join(RESOURCES_PATH, 'wms_caps_ncwms2_111.xml')
 WMS_CAPS_NCWMS2_130_XML = os.path.join(RESOURCES_PATH, 'wms_caps_ncwms2_130.xml')
 
-WPS_TEST_SERVICE = 'http://localhost:5000/wps'
+WPS_TEST_SERVICE = os.getenv("TWITCHER_TEST_WPS", "http://localhost:5000/wps")
 
 
 def dummy_request(dbsession):

--- a/tests/test_owsproxy.py
+++ b/tests/test_owsproxy.py
@@ -27,10 +27,10 @@ class OWSProxyTests(unittest.TestCase):
     def test_badrequest_url(self):
         request = DummyRequest(scheme='http')
         response = owsproxy_view(request)
-        assert isinstance(response, OWSAccessFailed) is True
+        assert isinstance(response, OWSAccessFailed)
 
     def test_badrequest_netloc(self):
         request = DummyRequest(scheme='http',
                                params={'url': 'http://'})
         response = owsproxy_view(request)
-        assert isinstance(response, OWSAccessFailed) is True
+        assert isinstance(response, OWSAccessFailed)

--- a/twitcher/owssecurity.py
+++ b/twitcher/owssecurity.py
@@ -2,6 +2,7 @@ from twitcher.exceptions import AccessTokenNotFound, ServiceNotFound
 from twitcher.owsexceptions import OWSAccessForbidden, OWSInvalidParameterValue
 from twitcher.utils import path_elements, parse_service_name
 from twitcher.owsrequest import OWSRequest
+from pyramid.httpexceptions import HTTPNotFound
 
 import logging
 LOGGER = logging.getLogger("TWITCHER")
@@ -71,7 +72,7 @@ class OWSSecurity(OWSSecurityInterface):
                     LOGGER.warning('public access for service %s', service_name)
             except ServiceNotFound:
                 raise OWSInvalidParameterValue(
-                    "Service not found", value="service")
+                    "Service not found", value="service", status_base=HTTPNotFound)
             ows_request = OWSRequest(request)
             if not ows_request.service_allowed():
                 raise OWSInvalidParameterValue(


### PR DESCRIPTION
When raising any `OWSException`, the returned response actually always indicate `200` which is confusing in case of unauthorized or bad requests cases.

This PR fixes this by making forbidden services have `401` (unauthorized), missing parameters have `400` (bad request), missing service `404` (not found), ect. The XML body is untouched.

`OWSException` can set `status_base` directly in the class definition, or pass it as input parameter when raised for custom status code for a given specific case. The value can be any of the int status code, the HTTPException type, or an HTTPException instance.
