### PR TITLE
avoid traceback on log owsexception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changes
 Unreleased
 ==========
 
+Changes:
+
+* Reduce log level of ``"failed security check"`` from ``exception`` to ``warning`` as it corresponds to the expected
+  code behavior (unauthorised access) when ``OWSException`` is raised, instead of dumping an unhandled error traceback.
+
 0.5.2 (2019-07-11)
 ==================
 

--- a/twitcher/tweens.py
+++ b/twitcher/tweens.py
@@ -27,7 +27,7 @@ def ows_security_tween_factory(handler, registry):
             security.check_request(request)
             return handler(request)
         except OWSException as err:
-            LOGGER.exception("security check failed.")
+            LOGGER.warning("security check failed.")
             return err
         except Exception as err:
             LOGGER.exception("unknown error")


### PR DESCRIPTION
Because the raised OWSException derives from Exception, logger.exception automatically resolves the exc_info and dumps the traceback. 
In this case, it is a valid 'security check failed', not an error. So simply emit a warning instead to avoid confusion with "breaking code".

Can also be merged to master, but I would like to stay on `0.5.x` version for now as I haven't implemented/tested complete compatibility with more recent changes and Magpie.