### PR TITLE
switch waitress for gunicorn

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -48,6 +48,10 @@ use = egg:gunicorn#main
 host = 0.0.0.0
 port = 8000
 
+# to use waitress instead:
+#use = egg:waitress#main
+#listen = 0.0.0.0:8000
+
 ###
 # logging configuration
 # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html

--- a/development.ini
+++ b/development.ini
@@ -44,8 +44,9 @@ file_template = %%(year)d%%(month).2d%%(day).2d_%%(rev)s
 # file_template = %%(rev)s_%%(slug)s
 
 [server:main]
-use = egg:waitress#main
-listen = 0.0.0.0:8000
+use = egg:gunicorn#main
+host = 0.0.0.0
+port = 8000
 
 ###
 # logging configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pyramid_debugtoolbar
 plaster_pastedeploy
 # wsgi
 gunicorn
+waitress
 # database
 pyramid_retry
 pyramid_tm

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyramid_debugtoolbar
 # deploy
 plaster_pastedeploy
 # wsgi
-waitress
+gunicorn
 # database
 pyramid_retry
 pyramid_tm


### PR DESCRIPTION
Fixes #97 

Replaces `waitress` by `gunicorn` by default. 
`waitress` seems to do some kind of deduplication of contents with extra read/write of chucks during data streaming.
I could not find any way to avoid `waitress` to do this with some option/flag. 

Tests results can be found here: 
https://github.com/bird-house/twitcher/issues/97#issuecomment-715642394
https://github.com/bird-house/twitcher/issues/97#issuecomment-716642107

I leave `waitress` in dependencies so that pre-existing deploys can use whichever they want between `gunicorn` / `waitress`. 
(if this is not an issue, we can remove it also)

**Important note:**
`gunicorn > 20` needs to be started with `pserve` to have correct port assigned. 
There is a change of parsing PasteDeploy config where starting directly with `gunicorn` doesn't detect the right port. 
(doesn't matter that much in this case, since default is `8000` which is also the one employed)

Regarless, Docker image was already using `pserve`, so everything should work just fine.