### PR TITLE
add smoke test of docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,14 @@ install:
   - pip install ".[dev]"
 stages:
   - test  # default (script)
-  - smoke-test
 jobs:
   include:
-    - stage: smoke-test
+    - stage: test
+      name: "Code Lint"
+      script: flake8
+    - stage: test
+      name: "Unit Tests"
+      script: make test-local
+    - stage: test
       name: "Smoke Test"
       script: make docker-build docker-test
-script:
-  - pytest -v -m 'not online' tests/
-  - flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 stages:
   - test  # default (script)
 jobs:
+  fast_finish: true
   include:
     - stage: test
       name: "Code Lint"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ install:
   - source activate twitcher
   # Install twitcher
   - pip install ".[dev]"
+jobs:
+  include:
+    - stage: test
+      name: "Smoke Test"
+      script: make docker-build docker-test
 script:
   - pytest -v -m 'not online' tests/
   - flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,12 @@ install:
   - source activate twitcher
   # Install twitcher
   - pip install ".[dev]"
+stages:
+  - test  # default (script)
+  - smoke-test
 jobs:
   include:
-    - stage: test
+    - stage: smoke-test
       name: "Smoke Test"
       script: make docker-build docker-test
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN apk update \
         libffi-dev \
         openssl-dev \
     && apk add --virtual .build-deps \
-        python-dev \
+        python3-dev \
+        py-pip \
         gcc \
         musl-dev \
     && pip install --no-cache-dir --upgrade pip setuptools \

--- a/Makefile
+++ b/Makefile
@@ -141,9 +141,9 @@ docker-test: docker-build docker-stop
 	sleep 2
 	echo "Testing docker image..."
 	@(curl http://localhost:8000 | grep "Twitcher Frontpage" && \
-	 $(MAKE) docker-stop --no-print-directory || \
- 	($(MAKE) docker-stop --no-print-directory && \
- 	 echo "Failed to obtain expected response from twitcher docker"; exit 1 ))
+	  $(MAKE) docker-stop --no-print-directory || \
+ 	 ($(MAKE) docker-stop --no-print-directory && \
+ 	  echo "Failed to obtain expected response from twitcher docker"; exit 1 ))
 
 ## Test targets
 
@@ -151,6 +151,11 @@ docker-test: docker-build docker-stop
 test:
 	@echo "Running tests (skip slow and online tests) ..."
 	@bash -c 'pytest -v -m "not slow and not online" tests/'
+
+.PHONY: test-local
+test:
+	@echo "Running tests (skip slow and online tests) ..."
+	@bash -c 'pytest -v -m "not online" tests/'
 
 .PHONY: test-all
 test-all:

--- a/Makefile
+++ b/Makefile
@@ -130,13 +130,13 @@ docker-push:
 
 .PHONY: docker-stop
 docker-stop:
-	@echo "Stopping test docker image: $(DOCKER_TEST)"
-	@-docker container stop "$(shell docker container ls -q --filter name=$(DOCKER_TEST))" 2>/dev/null || true
+	@echo "Stopping test docker container: $(DOCKER_TEST)"
+	@-docker container stop "$(DOCKER_TEST)" 2>/dev/null || true
 	@-docker rm $(DOCKER_TEST) 2>/dev/null || true
 
 .PHONY: docker-test
 docker-test: docker-build docker-stop
-	@echo "Smoke test of docker image: $(DOCKER_TAG)"
+	@echo "Smoke test of docker container: $(DOCKER_TAG)"
 	docker run --name $(DOCKER_TEST) -p 8000:8000 -d $(DOCKER_TAG)
 	sleep 2
 	echo "Testing docker image..."
@@ -153,7 +153,7 @@ test:
 	@bash -c 'pytest -v -m "not slow and not online" tests/'
 
 .PHONY: test-local
-test:
+test-local:
 	@echo "Running tests (skip slow and online tests) ..."
 	@bash -c 'pytest -v -m "not online" tests/'
 

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ docker-stop:
 
 .PHONY: docker-test
 docker-test: docker-build docker-stop
-	@echo "Smoke test of docker container: $(DOCKER_TAG)"
+	@echo "Smoke test of docker image: $(DOCKER_TAG)"
 	docker run --name $(DOCKER_TEST) -p 8000:8000 -d $(DOCKER_TAG)
 	sleep 2
 	echo "Testing docker image..."


### PR DESCRIPTION
Docker image v0.5.4 failed to build & deploy due to invalid dependencies to python(2) instead of python3. 

To detect this earlier (prior to merge of PR), I introduce a Travis-CI smoke-test of the image. 
Can be ported to 0.6.x / master branch as well.

Furthermore, I split the lint test / unittest / smoke test into individual parallel jobs to make it both faster and easier to identify the issue.

Latest result here: 
https://travis-ci.org/github/bird-house/twitcher/builds/740076733
