### PR TITLE
fix dependencies issues (6.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changes
 Unreleased
 ==========
 
+Fixes:
+
+* Pin packages ``zope.sqlalchemy>=1.5`` and ``sqlalchemy>=1.4,<2`` to avoid errors with conflicting and upcoming
+  release and features employed in code.
+* Fix failing ``cryptography`` package build step in Docker image due to missing ``g++`` and ``rust`` dependencies
+  (``rust`` installed via ``cargo``).
+
 0.6.0 (2020-04-01)
 ==================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,13 @@ RUN apk update \
         libxslt-dev \
         libxml2 \
         libffi-dev \
-        openssl-dev \
+        libressl-dev \
     && apk add --virtual .build-deps \
         python3-dev \
         py-pip \
+        cargo \
         gcc \
+        g++ \
         musl-dev \
     && pip install --no-cache-dir --upgrade pip setuptools \
     && pip install --no-cache-dir -e $TWITCHER_DIR \

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,13 @@ waitress
 pyramid_retry
 pyramid_tm
 alembic
-SQLAlchemy
+# 'sqlalchemy==2.0' breaks 'zope.sqlalchemy'
+# (https://github.com/zopefoundation/zope.sqlalchemy/issues/60)
+sqlalchemy>=1.4,<2
 transaction
-zope.sqlalchemy
+# avoid using 'zope.sqlalchemy==1.4' with regression since 'sqlalchemy==1.4' support
+# (https://github.com/zopefoundation/zope.sqlalchemy/pull/66)
+zope.sqlalchemy>=1.5
 # oauth2
 pyramid_oauthlib>=0.4.1
 oauthlib<3


### PR DESCRIPTION
## Changes

* Pin packages ``zope.sqlalchemy>=1.5`` and ``sqlalchemy>=1.4,<2`` to avoid errors with conflicting and upcoming
  release and features employed in code.
* Fix failing ``cryptography`` package build step in Docker image due to missing ``g++`` and ``rust`` dependencies
  (``rust`` installed via ``cargo``).


## See also

for 5.x (master) branch: https://github.com/bird-house/twitcher/pull/104