### PR TITLE
allow more flexible sqlalchemy version to work with magpie (relates t…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,8 @@ pyramid_tm
 alembic
 # 'sqlalchemy==2.0' breaks 'zope.sqlalchemy'
 # (https://github.com/zopefoundation/zope.sqlalchemy/issues/60)
-sqlalchemy>=1.4,<2
+sqlalchemy>=1.3,<2
 transaction
 # avoid using 'zope.sqlalchemy==1.4' with regression since 'sqlalchemy==1.4' support
 # (https://github.com/zopefoundation/zope.sqlalchemy/pull/66)
-zope.sqlalchemy>=1.5
+zope.sqlalchemy>=1.3,!=1.4.*


### PR DESCRIPTION
see related issues: 
- https://github.com/ergo/ziggurat_foundations/issues/71
- https://github.com/Ouranosinc/Magpie/pull/465

There is an error using `sqlalchemy==1.4` with underlying package `ziggurat_foundations` under `Magpie`. 
Until the fixes are released, this slightly more flexible requirements lets Magpie pick the more strict version of `sqlalchemy==1.3`.