### PR TITLE
fix incorrect search/replace term of bump config within Makefile

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,8 @@ replace =
 	==================
 
 [bumpversion:file:Makefile]
-search = VERSION := birdhouse/twitcher:{current_version}
-replace = {new_version}
+search = VERSION := {current_version}
+replace = VERSION := {new_version}
 
 [bumpversion:file:twitcher/__version__.py]
 search = __version__ = '{current_version}'


### PR DESCRIPTION
fix already applied in 0.5.x branch, cherry-pick for master/0.6.x