### PR TITLE
recompute OWSRegistry on demand to avoid caching issues with db-session

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changes
 Unreleased
 ==========
 
+Changes:
+
+* Enforce regeneration of the ``OWSRegistry`` object on each request to avoid incorrect handling by adapters that
+  require the new transaction or refreshed database session state each time.
+
 0.6.1 (2021-10-27)
 ==================
 

--- a/twitcher/owsregistry.py
+++ b/twitcher/owsregistry.py
@@ -95,4 +95,11 @@ def includeme(config):
     def owsregistry(request):
         adapter = get_adapter_factory(request)
         return adapter.owsregistry_factory(request)
-    config.add_request_method(owsregistry, reify=True)
+
+    # In case the adapter employs caching or other per-request/session dependent transaction details, we must ensure
+    # to regenerate the owsregistry object each time since the service-store it provides (amongst other things),
+    # only initializes the request once instead of per-request method calls.
+    # For example, 'request.owsregistry.get_service_by_name' will call 'ServiceStore.fetch_by_name' with
+    # the 'ServiceStore' initialized and stored with the first ever request (if reify=True). All following service
+    # operations would employ the stored database session contained within this request.
+    config.add_request_method(owsregistry, reify=False, property=True)


### PR DESCRIPTION
## Description

This resolves many long standing issues related to request caching negotiation between Magpie and Twitcher.
As illustrated in this test results, many requests are failing due to `NoTransaction` error: 
https://github.com/bird-house/birdhouse-deploy/pull/197#issuecomment-982061802

Following this fix (manually integrated in [Ouranosinc/Magpie@`ae1698a` (#488)](https://github.com/Ouranosinc/Magpie/pull/488/commits/ae1698aaa5c3c6b3e80b24c865a8d6c82303090d) and corresponding Magpie & Twitcher Dockers pushed with manual tags), following results are obtained.


*ignore `weaver` errors that are unrelated, all else are gone including notably `stress-tests`* 
http://daccs-jenkins.crim.ca/job/DACCS-iac-birdhouse/789
http://daccs-jenkins.crim.ca/job/PAVICS-e2e-workflow-tests/job/master/672
```
14:33:53  ============================= test session starts ==============================
14:33:53  platform linux -- Python 3.7.10, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
14:33:53  rootdir: /home/jenkins/agent/workspace/PAVICS-e2e-workflow-tests_master
14:33:53  plugins: anyio-3.3.0, dash-1.21.0, nbval-0.9.6, tornasync-0.6.0.post2
14:33:53  collected 222 items
14:33:53  
14:34:07  notebooks-auth/test_thredds.ipynb ...........                            [  4%]
14:34:33  pavics-sdi-master/docs/source/notebooks/WCS_example.ipynb .......        [  8%]
14:34:43  pavics-sdi-master/docs/source/notebooks/WFS_example.ipynb ......         [ 10%]
14:34:52  pavics-sdi-master/docs/source/notebooks/WMS_example.ipynb ........       [ 14%]
14:34:55  pavics-sdi-master/docs/source/notebooks/WPS_example.ipynb ..........     [ 18%]
14:35:10  pavics-sdi-master/docs/source/notebooks/esgf-dap.ipynb .                 [ 19%]
14:35:11  pavics-sdi-master/docs/source/notebooks/jupyter_extensions.ipynb .       [ 19%]
14:35:16  pavics-sdi-master/docs/source/notebooks/opendap.ipynb .......            [ 22%]
14:35:23  pavics-sdi-master/docs/source/notebooks/pavics_thredds.ipynb .....       [ 25%]
14:39:13  pavics-sdi-master/docs/source/notebooks/regridding.ipynb ............... [ 31%]
14:40:04  ..............                                                           [ 38%]
14:40:11  pavics-sdi-master/docs/source/notebooks/rendering.ipynb ....             [ 40%]
14:40:13  pavics-sdi-master/docs/source/notebooks/subset-user-input.ipynb ........ [ 43%]
14:40:42  .................                                                        [ 51%]
14:40:49  pavics-sdi-master/docs/source/notebooks/subsetting.ipynb .....           [ 53%]
14:40:52  pavics-sdi-master/docs/source/notebook-components/weaver_example.ipynb . [ 54%]
14:40:54  .FFFFFFFF.                                                               [ 58%]
14:41:06  finch-master/docs/source/notebooks/dap_subset.ipynb ..........           [ 63%]
14:41:15  finch-master/docs/source/notebooks/finch-usage.ipynb ......              [ 65%]
14:41:59  finch-master/docs/source/notebooks/subset.ipynb ....................     [ 74%]
14:42:00  PAVICS-landing-master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-1DataAccess.ipynb . [ 75%]
14:42:05  ......                                                                   [ 77%]
14:42:44  PAVICS-landing-master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-2Subsetting.ipynb . [ 78%]
14:43:04  .............                                                            [ 84%]
14:43:15  PAVICS-landing-master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb . [ 84%]
14:45:47  ....s.                                                                   [ 87%]
14:45:59  PAVICS-landing-master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-4Ensembles.ipynb . [ 87%]
14:46:06  ...                                                                      [ 89%]
14:46:33  PAVICS-landing-master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb . [ 89%]
14:47:01  ......                                                                   [ 92%]
14:47:06  notebooks/hummingbird.ipynb ............                                 [ 97%]
14:50:32  notebooks/stress-tests.ipynb .....                                       [100%]
14:50:32  
14:50:32  =================================== FAILURES ===================================
```

After this PR is integrated, I will properly tag/bump Twitcher with `0.6.2` and apply it to Magpie for `3.19.0` release.

## References
- resolves https://github.com/bird-house/birdhouse-deploy/pull/197
- relates to https://github.com/Ouranosinc/Magpie/issues/466
- relates to https://github.com/Ouranosinc/Magpie/issues/433
- relates to https://github.com/bird-house/birdhouse-deploy/pull/174
- relates to https://github.com/bird-house/birdhouse-deploy/pull/182
- relates to https://github.com/bird-house/birdhouse-deploy/pull/188


