### PR TITLE
move ows proxy `send_request` function under corresponding adapter method

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8"]
         allow-failure: [false]
         test-case: [test-local]
         include:
@@ -61,6 +61,11 @@ jobs:
             python-version: None  # doesn't matter which one (in docker), but match default of repo
             allow-failure: false
             test-case: docker-test
+          # deprecated versions
+          - os: ubuntu-20.04
+            python-version: 3.6
+            allow-failure: false
+            test-case: test-local
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,15 @@ Changes
 Unreleased
 ==========
 
+Changes:
+
+* Add the OWS proxy ``send_request`` operation under the ``twitcher.adapter`` interface to allow it applying relevant
+  proxying adjustments when using derived implementation. The ``DefaultAdapater`` simply calls the original funciton
+  that was previously called directly instead of using the adapter's method.
+* Removed the ``extra_path`` and ``request_params`` arguments from OWS proxy ``send_request`` to better align them with
+  arguments from other adapter methods. These parameters are directly retrieved from the ``request`` argument which was
+  also provided as input to ``send_request``.
+
 0.7.0 (2022-05-11)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,12 +6,22 @@ Unreleased
 
 Changes:
 
+* Add ``/ows/verify/{service_name}[/{extra_path}]`` endpoint analoguous to ``/ows/proxy/{service_name}[/{extra_path}]``
+  to only verify if access is granted to this service, for that specific resource path, and for the authenticated user,
+  without perfoming the proxied request. This can be employed by servers and external entities to validate that
+  authorization will be granted for the user without executing potentially heavy computation or large data transfers
+  from the targetted resource that would otherwise be performed by requesting the ``/ows/proxy`` equivalent location.
+  One usage example of this feature is using |nginx-auth|_ to verify an alternate resource prior to proxing a service
+  request that needs authenticated access to the first resource.
 * Add the OWS proxy ``send_request`` operation under the ``twitcher.adapter`` interface to allow it applying relevant
   proxying adjustments when using derived implementation. The ``DefaultAdapater`` simply calls the original function
   that was previously called directly instead of using the adapter's method.
 * Removed the ``extra_path`` and ``request_params`` arguments from OWS proxy ``send_request`` to better align them with
   arguments from other adapter methods. These parameters are directly retrieved from the ``request`` argument, which was
   also provided as input to ``send_request``.
+
+.. _nginx-auth: https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/
+.. |nginx-auth| replace:: NGINX Authentication Based on Subrequest Result
 
 0.7.0 (2022-05-11)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,10 +8,10 @@ Changes:
 
 * Add ``/ows/verify/{service_name}[/{extra_path}]`` endpoint analoguous to ``/ows/proxy/{service_name}[/{extra_path}]``
   to only verify if access is granted to this service, for that specific resource path, and for the authenticated user,
-  without perfoming the proxied request. This can be employed by servers and external entities to validate that
+  without performing the proxied request. This can be employed by servers and external entities to validate that
   authorization will be granted for the user without executing potentially heavy computation or large data transfers
-  from the targetted resource that would otherwise be performed by requesting the ``/ows/proxy`` equivalent location.
-  One usage example of this feature is using |nginx-auth|_ to verify an alternate resource prior to proxing a service
+  from the targeted resource that would otherwise be performed by requesting the ``/ows/proxy`` equivalent location.
+  One usage example of this feature is using |nginx-auth|_ to verify an alternate resource prior to proxying a service
   request that needs authenticated access to the first resource.
 * Add the OWS proxy ``send_request`` operation under the ``twitcher.adapter`` interface to allow it applying relevant
   proxying adjustments when using derived implementation. The ``DefaultAdapater`` simply calls the original function

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,10 @@ Unreleased
 Changes:
 
 * Add the OWS proxy ``send_request`` operation under the ``twitcher.adapter`` interface to allow it applying relevant
-  proxying adjustments when using derived implementation. The ``DefaultAdapater`` simply calls the original funciton
+  proxying adjustments when using derived implementation. The ``DefaultAdapater`` simply calls the original function
   that was previously called directly instead of using the adapter's method.
 * Removed the ``extra_path`` and ``request_params`` arguments from OWS proxy ``send_request`` to better align them with
-  arguments from other adapter methods. These parameters are directly retrieved from the ``request`` argument which was
+  arguments from other adapter methods. These parameters are directly retrieved from the ``request`` argument, which was
   also provided as input to ``send_request``.
 
 0.7.0 (2022-05-11)

--- a/twitcher/adapter/base.py
+++ b/twitcher/adapter/base.py
@@ -85,3 +85,16 @@ class AdapterInterface(object):
         This method can modify the response to adapt it for specific service logic.
         """
         raise NotImplementedError
+
+    def send_request(self, request, service):
+        # type: (Request, ServiceConfig) -> Response
+        """
+        Performs the provided request in order to obtain a proxied response.
+
+        .. versionadded:: 0.8.0
+
+        The operation should consider the service definition to resolve where the
+        request redirection should be proxied to, and handle any relevant response
+        errors, such as an unauthorized access or an unreachable service.
+        """
+        raise NotImplementedError

--- a/twitcher/adapter/default.py
+++ b/twitcher/adapter/default.py
@@ -3,6 +3,7 @@ Factories to create storage backends.
 """
 
 from twitcher.adapter.base import AdapterInterface
+from twitcher.owsproxy import send_request
 from twitcher.owssecurity import OWSSecurity
 from twitcher.owsregistry import OWSRegistry
 from twitcher.store import ServiceStore
@@ -43,3 +44,7 @@ class DefaultAdapter(AdapterInterface):
 
     def response_hook(self, response, service):
         return response
+
+    def send_request(self, request, service):
+        # type: (Request, ServiceConfig) -> Response
+        return send_request(request, service)

--- a/twitcher/adapter/default.py
+++ b/twitcher/adapter/default.py
@@ -10,6 +10,13 @@ from twitcher.store import ServiceStore
 from twitcher.utils import get_settings
 from pyramid.config import Configurator
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from pyramid.request import Request
+    from pyramid.response import Response
+
+    from twitcher.models.service import ServiceConfig
+
 TWITCHER_ADAPTER_DEFAULT = 'default'
 
 

--- a/twitcher/owsproxy.py
+++ b/twitcher/owsproxy.py
@@ -18,7 +18,7 @@ import logging
 LOGGER = logging.getLogger('TWITCHER')
 
 if TYPE_CHECKING:
-    from typing import Iterator, Optional
+    from typing import Iterator
 
     from pyramid.config import Configurator
     from pyramid.request import Request

--- a/twitcher/utils.py
+++ b/twitcher/utils.py
@@ -66,12 +66,15 @@ def is_json_serializable(item):
 
 
 def parse_service_name(url, protected_path):
+    # type: (str, str) -> Optional[str]
     parsed_url = urlparse.urlparse(url)
     service_name = None
     if parsed_url.path.startswith(protected_path):
         parts_without_protected_path = parsed_url.path[len(protected_path)::].strip('/').split('/')
-        if 'proxy' in parts_without_protected_path:
-            parts_without_protected_path.remove('proxy')
+        # use ranges to avoid index error in case the path parts list is empty
+        # the expected part must be exactly the first one after the protected path, then followed by the service name
+        if any(part in parts_without_protected_path[:1] for part in ['proxy', 'verify']):
+            parts_without_protected_path = parts_without_protected_path[1:]
         if len(parts_without_protected_path) > 0:
             service_name = parts_without_protected_path[0]
     if not service_name:


### PR DESCRIPTION
## Changes:

* Add ``/ows/verify/{service_name}[/{extra_path}]`` endpoint analoguous to ``/ows/proxy/{service_name}[/{extra_path}]``
  to only verify if access is granted to this service, for that specific resource path, and for the authenticated user,
  without performing the proxied request. This can be employed by servers and external entities to validate that
  authorization will be granted for the user without executing potentially heavy computation or large data transfers
  from the targeted resource that would otherwise be performed by requesting the ``/ows/proxy`` equivalent location.
  One usage example of this feature is using  [NGINX Authentication Based on Subrequest Result](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/) to verify an alternate resource prior to proxying a service
  request that needs authenticated access to the first resource.
* Add the OWS proxy ``send_request`` operation under the ``twitcher.adapter`` interface to allow it applying relevant
  proxying adjustments when using derived implementation. The ``DefaultAdapater`` simply calls the original function
  that was previously called directly instead of using the adapter's method.
* Removed the ``extra_path`` and ``request_params`` arguments from OWS proxy ``send_request`` to better align them with
  arguments from other adapter methods. These parameters are directly retrieved from the ``request`` argument, which was
  also provided as input to ``send_request``.

## Purpose

This is used in conjunction of https://github.com/Ouranosinc/Magpie/pull/571
Without this fix, there is no way for Magpie to retrieve the link between the proxied `request`/`response`, as this was all contained within `send_request`. 

## To Do
Twitcher `0.8.0` will be tagged (and should be released) after merge in order to build the new Docker required by Magpie.
