### PR TITLE
fix duplicate pypi upload error during tagged github action workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,8 @@ jobs:
 
   deploy_pypi:
     needs: tests
-    if: ${{ success() && (contains(github.ref, 'refs/tags') || github.ref == 'refs/heads/master') }}
+    # Don't match master branch for upload to avoid duplicate error, even if the tag is usually applied on master.
+    if: ${{ success() && github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -123,3 +124,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          verbose: true  # For debugging 'twine upload' if a problem occurs.

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='pyramid_twitcher',
       version=about['__version__'],
       description=about['__doc__'],
       long_description=README + '\n\n' + CHANGES,
+      long_description_content_type="text/x-rst",
       classifiers=[
           "Development Status :: 4 - Beta",
           "Framework :: Pyramid",


### PR DESCRIPTION
## Fixes

- Fix the duplicate PyPi upload issue raised in https://github.com/bird-house/twitcher/actions/runs/4066131577/jobs/7001820259 (on push tag), although the upload worked in https://github.com/bird-house/twitcher/actions/runs/4066131375/jobs/7001815006 (on push master), and the package is properly defined at https://pypi.org/project/pyramid-twitcher/0.8.0/.
- Apply `long_description_content_type` that was flagged as warning during the PyPi deploy step.