### PR TITLE
Fix invalid tornado dependency in tests

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,4 @@ nbsphinx
 bump2version
 twine
 mock
-tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
+tornado>=6.3.3; python_version >= "3.8"  # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Fix problem introduced by https://github.com/bird-house/twitcher/pull/126


https://github.com/bird-house/twitcher/actions/runs/5878573929/job/15940922706
```
INFO: pip is looking at multiple versions of pyramid-twitcher[dev] to determine which version is compatible with other requirements. This could take a while.
ERROR: Ignored the following versions that require a different python version: 6.0.0 Requires-Python >=3.8; 6.0.0 Requires-Python >=3.8.1; 6.0.0b1 Requires-Python >=3.8; 6.0.0b2 Requires-Python >=3.8; 6.0.1 Requires-Python >=3.8; 6.1.0 Requires-Python >=3.8; 6.1.0 Requires-Python >=3.8.1; 6.1.1 Requires-Python >=3.8; 6.1.2 Requires-Python >=3.8; 6.1.3 Requires-Python >=3.8; 6.2.0 Requires-Python >=3.8; 6.2.1 Requires-Python >=3.8; 6.3 Requires-Python >= 3.8; 6.3.1 Requires-Python >= 3.8; 6.3.2 Requires-Python >= 3.8; 6.3.3 Requires-Python >= 3.8; 6.3b1 Requires-Python >= 3.8; 7.0.0 Requires-Python >=3.8; 7.0.0rc1 Requires-Python >=3.8; 7.0.1 Requires-Python >=3.8; 7.1.0 Requires-Python >=3.8; 7.1.1 Requires-Python >=3.8; 7.1.2 Requires-Python >=3.8
ERROR: Could not find a version that satisfies the requirement tornado>=6.3.3; extra == "dev" (from pyramid-twitcher[dev]) (from versions: 0.2, 1.0, 1.1, 1.1.1, 1.2, 1.2.1, 2.0, 2.1, 2.1.1, 2.2, 2.2.1, 2.3, 2.4, 2.4.1, 3.0, 3.0.1, 3.0.2, 3.1, 3.1.1, 3.2, 3.2.1, 3.2.2, 4.0, 4.0.1, 4.0.2, 4.1b2, 4.1, 4.2b1, 4.2, 4.2.1, 4.3b1, 4.3b2, 4.3, 4.4b1, 4.4, 4.4.1, 4.4.2, 4.4.3, 4.5b1, 4.5b2, 4.5, 4.5.1, 4.5.2, 4.5.3, 5.0a1, 5.0b1, 5.0, 5.0.1, 5.0.2, 5.1b1, 5.1, 5.1.1, 6.0a1, 6.0b1, 6.0, 6.0.1, 6.0.2, 6.0.3, 6.0.4, 6.1b1, 6.1b2, 6.1, 6.2b1, 6.2b2, 6.2)
ERROR: No matching distribution found for tornado>=6.3.3; extra == "dev"
```