### PR TITLE
update security pins for `waitress`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ pyramid_debugtoolbar
 plaster_pastedeploy
 # wsgi
 gunicorn
-waitress
+waitress==3.0.0; python_version < "3.9"  # noqa
+waitress>=3.0.2; python_version >= "3.9"
 # database
 pyramid_retry
 pyramid_tm


### PR DESCRIPTION
See https://github.com/Pylons/waitress/releases for supported Python version details

Applied versions are explicitly updating what should be installed by default from unpinned versions to ensure security fixes are obtained.

Python 3.8 is pinned to latest available to address as much security vulnerabilities as possible, but should be avoided if possible since EOL. Preserved only for legacy reference.