### PR TITLE
add docker-build/push to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 # run test suites
 
-name: Tests
+name: Tests and Deployment
 on:
   - pull_request
   - push
@@ -13,9 +13,13 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # see: https://github.com/fkirc/skip-duplicate-actions
   skip_duplicate:
+    name: Skip Duplicate Workflows
     continue-on-error: true
     runs-on: ubuntu-latest
     outputs:
@@ -30,6 +34,7 @@ jobs:
 
   # see: https://github.com/actions/setup-python
   tests:
+    name: Test
     needs: skip_duplicate
     if: ${{ needs.skip_duplicate.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
@@ -71,14 +76,17 @@ jobs:
             allow-failure: false
             test-case: test-local
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: "0"
-      - name: Setup Python
-        uses: actions/setup-python@v5
+          persist-credentials: false
+      - name: Set up Python3
         if: ${{ matrix.python-version != 'None' }}
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install Dependencies
         if: ${{ matrix.python-version != 'None' }}
         # install package and dependencies directly,
@@ -97,7 +105,7 @@ jobs:
         if: ${{ matrix.python-version == 'None' }}
         run: make docker-stop
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         if: ${{ success() && matrix.test-case == 'coverage' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -105,51 +113,61 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
+  # FIXME: We should split the deployment job into its own workflow. Token-based updates to PyPI are heavily discouraged in favour of Trusted Publishing.
   deploy_pypi:
+    name: Deploy (PyPI)
     needs: tests
     # Don't match master branch for upload to avoid duplicate error, even if the tag is usually applied on master.
     if: ${{ success() && github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: "0"
-      - name: Setup Python
-        uses: actions/setup-python@v5
+          persist-credentials: false
+
+      - name: Set up Python3
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: "3.11"
+
       - name: Build Distribution Package
-        run: make develop dist
+        run: |
+          make develop dist
+
       - name: Push Package to PyPi
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true  # For debugging 'twine upload' if a problem occurs.
 
   deploy_docker:
+    name: Deploy (DockerHub)
     needs: tests
     if: ${{ success() && (contains(github.ref, 'refs/tags') || github.ref == 'refs/heads/master') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - name: Checkout Repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: "0"
-      - name: Get Tag Version
-        id: version
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
-            echo "::set-output name=TAG_VERSION::latest"
-          else
-            echo "::set-output name=TAG_VERSION::${GITHUB_REF##*/}"
-          fi
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      # FIXME: We should be using a PAT generated specifically for this. docker/build-push-action accepts PATs directly.
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build Docker
-        run: make APP_VERSION=${{ steps.version.outputs.TAG_VERSION }} docker-build
-      - name: Push to DockerHub
-        run: make APP_VERSION=${{ steps.version.outputs.TAG_VERSION }} docker-push
+
+      - name: Build Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          file: "Dockerfile"
+          push: true
+          tags: birdhouse/twitcher:latest,birdhouse/twitcher:${{ GITHUB_REF##*/ }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,4 +170,4 @@ jobs:
         with:
           file: "Dockerfile"
           push: true
-          tags: birdhouse/twitcher:latest,birdhouse/twitcher:${{ GITHUB_REF##*/ }}
+          tags: birdhouse/twitcher:latest,birdhouse/twitcher:${{ github.ref_name }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,3 +126,30 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true  # For debugging 'twine upload' if a problem occurs.
+
+  deploy_docker:
+    needs: tests
+    if: ${{ success() && (contains(github.ref, 'refs/tags') || github.ref == 'refs/heads/master') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - name: Get Tag Version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
+            echo "::set-output name=TAG_VERSION::latest"
+          else
+            echo "::set-output name=TAG_VERSION::${GITHUB_REF##*/}"
+          fi
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build Docker
+        run: make APP_VERSION=${{ steps.version.outputs.TAG_VERSION }} docker-build
+      - name: Push to DockerHub
+        run: make APP_VERSION=${{ steps.version.outputs.TAG_VERSION }} docker-push

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
     if: ${{ success() && (contains(github.ref, 'refs/tags') || github.ref == 'refs/heads/master') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: "0"
       - name: Get Tag Version


### PR DESCRIPTION
Since DockerHub does not provide cloud build anymore for free tier, build it ourselves here and push it. For the recent https://github.com/bird-house/twitcher/releases/tag/v0.11.0, I pushed it manually (https://hub.docker.com/repository/docker/birdhouse/twitcher/tags/v0.11.0/sha256:4d88c6afc3011fe4960bf81584b16244954d15db99babb7fcd591f8768d1143f). This CI update should do the same once tagged or on master.

I've set up a token with CRIM user for now. Can be updated to a birdhouse-specific token as desired (I do not have access to birdhouse org tokens within DockerHub). 
